### PR TITLE
Fix minor bug with word adjustment during fixups

### DIFF
--- a/org2asm.tcl
+++ b/org2asm.tcl
@@ -562,7 +562,7 @@ proc emitword {w} {
 	    add_fixup [expr $::ADDR-$::OVER_ORG]
 
 	    # Adjust word so it is fixed up corectly
-	    if { [info exists ::OVER_START(::CURRENT_OVER)] } {
+	    if { [info exists ::OVER_START($::CURRENT_OVER)] } {
 		set w [expr $w - $::OVER_START($::CURRENT_OVER)]
 	    }
 	    set ::FIXED "*"


### PR DESCRIPTION
Hi Andrew, it's James here from the Organiser II forum, working on ORGNET.

I was having a minor issue with getting the fixups to work when my code was relocated to RAM, as I realised that the labels I used for addresses in my overlay code all appeared in the binary file as being relative to `$241B` instead of `0`. It turns out the assembler wasn't subtracting the offset set by `.ORG` correctly when I ran it on my computer, because it appeared that there was a minor typo in the overlay checking condition under `emitword`.

So here's what is quite possibly the smallest pull request ever — inserting a `$` to ensure that `info exists ::OVER_START($::CURRENT_OVER)` works correctly! I did also try and search for more instances where the `$` is missing, and it appears that that was the only one.

Otherwise, it's been fantastic using your assembler so far — it seems to be working really well!

Many thanks,
-James.